### PR TITLE
Make FakeUnleash differ "not set" from disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/no/finn/unleash/FakeUnleash.java
+++ b/src/main/java/no/finn/unleash/FakeUnleash.java
@@ -1,11 +1,12 @@
 package no.finn.unleash;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class FakeUnleash implements Unleash {
     private boolean enableAll = false;
-    private Set<String> enabledFeatures = new HashSet<>();
+    private boolean disableAll = false;
+    private Map<String, Boolean> features = new HashMap<>();
 
     @Override
     public boolean isEnabled(String toggleName) {
@@ -16,31 +17,46 @@ public final class FakeUnleash implements Unleash {
     public boolean isEnabled(String toggleName, boolean defaultSetting) {
         if(enableAll) {
             return true;
-        } else if(enabledFeatures.contains(toggleName)) {
-            return true;
+        } else if(disableAll) {
+            return false;
         } else {
-            return defaultSetting;
+            return features.getOrDefault(toggleName, defaultSetting);
         }
     }
 
     public void enableAll() {
+        disableAll = false;
         enableAll = true;
+        features.clear();
     }
 
     public void disableAll() {
-        enabledFeatures = new HashSet<>();
+        disableAll = true;
         enableAll = false;
+        features.clear();
+    }
+
+    public void resetAll() {
+        disableAll = false;
+        enableAll = false;
+        features.clear();
     }
 
     public void enable(String... features) {
         for(String name: features) {
-            enabledFeatures.add(name);
+            this.features.put(name, true);
         }
     }
 
     public void disable(String... features) {
         for(String name: features) {
-            enabledFeatures.remove(name);
+            this.features.put(name, false);
+        }
+    }
+
+    public void reset(String... features) {
+        for(String name: features) {
+            this.features.remove(name);
         }
     }
 }

--- a/src/test/java/no/finn/unleash/FakeUnleashTest.java
+++ b/src/test/java/no/finn/unleash/FakeUnleashTest.java
@@ -44,4 +44,41 @@ public class FakeUnleashTest {
         assertThat(fakeUnleash.isEnabled("t1"), is(true));
         assertThat(fakeUnleash.isEnabled("t2"), is(false));
     }
+
+    @Test
+    public void should_be_disabled_even_when_true_is_default() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.disable("t1");
+
+        assertThat(fakeUnleash.isEnabled("t1", true), is(false));
+    }
+
+    @Test
+    public void should_be_disabled_on_disable_all_with_true_as_default() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.disableAll();
+
+        assertThat(fakeUnleash.isEnabled("t1", true), is(false));
+    }
+
+    @Test
+    public void should_be_able_to_reset_all_disables() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.disable("t1");
+        fakeUnleash.resetAll();
+        assertThat(fakeUnleash.isEnabled("t1", true), is(true));
+
+    }
+
+    @Test
+    public void should_be_able_to_reset_single_disable() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.disable("t1");
+        fakeUnleash.disable("t2");
+        fakeUnleash.reset("t1");
+
+        assertThat(fakeUnleash.isEnabled("t1", true), is(true));
+        assertThat(fakeUnleash.isEnabled("t2", true), is(false));
+
+    }
 }


### PR DESCRIPTION
In FakeUnleash, you can't really set a toggle to be disabled, as it just unsets the enabled feature. This meant that unleash.enabled("feature", true) would incorrectly return true for a disabled feature.